### PR TITLE
Add ApiKeyContext unit test and publish artifacts in CI

### DIFF
--- a/.github/workflows/export-to-gmail.yml
+++ b/.github/workflows/export-to-gmail.yml
@@ -15,6 +15,9 @@ on:
 env:
   JAVA_VERSION: 21
   WORKING_DIRECTORY: modules/export-to-gmail
+  MAVEN_USERNAME: ${{ github.actor }}
+  MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+  GITHUB_PACKAGES_URL: https://maven.pkg.github.com/${{ github.repository }}
 
 permissions:
   contents: read
@@ -26,10 +29,6 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # permissions:
-    #   contents: read
-    #   packages: write
-    #   id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -40,8 +39,27 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'temurin'
           cache: maven
-        
-      - name: Test with Maven
-        run: |
-          mvn -B clean package --file pom.xml
+          server-id: github
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+
+      - name: Build and test with Maven
+        run: mvn -B -ntp clean verify --file pom.xml
         working-directory: ${{ env.WORKING_DIRECTORY }}
+
+      - name: Publish test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: export-to-gmail-test-results
+          path: ${{ env.WORKING_DIRECTORY }}/target/surefire-reports
+
+      - name: Publish JAR to GitHub Packages
+        if: github.event_name == 'push'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          mvn -B -ntp deploy -DskipTests --file pom.xml
+          -DaltDeploymentRepository=github::default::${{ env.GITHUB_PACKAGES_URL }}
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+

--- a/modules/export-to-gmail/src/test/java/com/github/sigmalko/pmetg/ApiKeyContextTest.java
+++ b/modules/export-to-gmail/src/test/java/com/github/sigmalko/pmetg/ApiKeyContextTest.java
@@ -1,0 +1,35 @@
+package com.github.sigmalko.pmetg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ApiKeyContextTest {
+
+    private ApiKeyContext apiKeyContext;
+
+    @BeforeEach
+    void setUp() {
+        apiKeyContext = new ApiKeyContext();
+    }
+
+    @Test
+    void apiKeyReturnsEmptyOptionalWhenKeyIsNotSet() {
+        assertThat(apiKeyContext.apiKey()).isEmpty();
+    }
+
+    @Test
+    void apiKeyReturnsEmptyOptionalWhenKeyIsBlank() {
+        apiKeyContext.setApiKey("   ");
+
+        assertThat(apiKeyContext.apiKey()).isEmpty();
+    }
+
+    @Test
+    void apiKeyReturnsOptionalWithKeyWhenKeyIsProvided() {
+        apiKeyContext.setApiKey("secret-key");
+
+        assertThat(apiKeyContext.apiKey()).contains("secret-key");
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit 5 coverage for ApiKeyContext request-scoped storage behavior
- extend the export-to-gmail workflow to upload test reports and deploy the JAR to GitHub Packages

## Testing
- mvn -B -ntp clean test

------
https://chatgpt.com/codex/tasks/task_e_68e27e3a5a70832bb2451db265943a3c