### PR TITLE
Update Maven altDeploymentRepository syntax

### DIFF
--- a/.github/workflows/export-to-gmail.yml
+++ b/.github/workflows/export-to-gmail.yml
@@ -60,6 +60,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: >-
           mvn -B -ntp deploy -DskipTests --file pom.xml
-          -DaltDeploymentRepository=github::default::${{ env.GITHUB_PACKAGES_URL }}
+          -DaltDeploymentRepository=github::${{ env.GITHUB_PACKAGES_URL }}
         working-directory: ${{ env.WORKING_DIRECTORY }}
 


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to use the modern altDeploymentRepository syntax for GitHub Packages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2801daa2c832b8fee26c83d9fd4e7