### PR TITLE
Add Gmail IMAP header logging

### DIFF
--- a/modules/export-to-gmail/pom.xml
+++ b/modules/export-to-gmail/pom.xml
@@ -10,7 +10,7 @@
         </parent>
 	<groupId>com.github.sigmalko.pmetg</groupId>
         <artifactId>proton-mail-export-to-gmail</artifactId>
-        <version>0.0.6-SNAPSHOT</version>
+        <version>0.0.7-SNAPSHOT</version>
 	<name>proton-mail-export-to-gmail</name>
 	<description>proton-mail-export-to-gmail</description>
 	<url/>

--- a/modules/export-to-gmail/src/main/java/com/github/sigmalko/pmetg/gmail/EmailHeader.java
+++ b/modules/export-to-gmail/src/main/java/com/github/sigmalko/pmetg/gmail/EmailHeader.java
@@ -3,9 +3,9 @@ package com.github.sigmalko.pmetg.gmail;
 import java.time.Instant;
 
 public record EmailHeader(
-        String from,
-        String to,
+        int messageNumber,
+        String messageId,
         Instant sentAt,
-        String messageId
+        String from
 ) {
 }


### PR DESCRIPTION
## Summary
- fetch the latest Gmail message headers up to the configured limit without downloading bodies or attachments
- log each message's index, Message-ID, sent date, and sender at INFO level
- update the EmailHeader record and bump the module version to capture the new data shape

## Testing
- mvn clean package

------
https://chatgpt.com/codex/tasks/task_e_68e2d1bb0170832b8fba244759be4cbb