### PR TITLE
Include README asset in release workflow

### DIFF
--- a/.github/workflows/export-to-gmail.yml
+++ b/.github/workflows/export-to-gmail.yml
@@ -93,6 +93,8 @@ jobs:
             echo "Uploading $file"
             gh release upload "${{ steps.set_version.outputs.target_version }}" "$file" --clobber
           done
+          echo "Uploading ../../README.md"
+          gh release upload "${{ steps.set_version.outputs.target_version }}" "../../README.md#README.md" --clobber
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}            
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         

--- a/modules/export-to-gmail/pom.xml
+++ b/modules/export-to-gmail/pom.xml
@@ -10,7 +10,7 @@
         </parent>
 	<groupId>com.github.sigmalko.pmetg</groupId>
 	        <artifactId>proton-mail-export-to-gmail</artifactId>
-	        <version>0.0.9-SNAPSHOT</version>
+                <version>0.0.10-SNAPSHOT</version>
 	<name>proton-mail-export-to-gmail</name>
 	<description>proton-mail-export-to-gmail</description>
 	<url/>


### PR DESCRIPTION
## Summary
- upload the repository README.md as a release asset alongside the built JARs
- bump the export-to-gmail module version to 0.0.10-SNAPSHOT

## Testing
- mvn -B -ntp clean package

------
https://chatgpt.com/codex/tasks/task_e_68e2ed898a28832bb193bcda6e10f75f