### PR TITLE
Switch Proton Drive import image to Ubuntu

### DIFF
--- a/modules/import-from-protondrive/Dockerfile
+++ b/modules/import-from-protondrive/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1.7
+
+FROM ubuntu:24.04
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL https://downloads.rclone.org/rclone-current-linux-amd64.zip -o /tmp/rclone.zip \
+    && unzip /tmp/rclone.zip -d /tmp \
+    && install -m 755 /tmp/rclone-*-linux-amd64/rclone /usr/local/bin/rclone \
+    && rm -rf /tmp/rclone*
+
+ENTRYPOINT ["rclone"]
+CMD ["--help"]


### PR DESCRIPTION
## Summary
- switch the Proton Drive import module container to the Ubuntu 24.04 base image

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2fa8e234c832b87a21248a24fb401