### PR TITLE
Fix H2 configuration incompatibility

### DIFF
--- a/modules/export-to-gmail/pom.xml
+++ b/modules/export-to-gmail/pom.xml
@@ -10,7 +10,7 @@
         </parent>
 	<groupId>com.github.sigmalko.pmetg</groupId>
 	        <artifactId>proton-mail-export-to-gmail</artifactId>
-    <version>0.0.14-SNAPSHOT</version>
+    <version>0.0.15-SNAPSHOT</version>
 	<name>proton-mail-export-to-gmail</name>
 	<description>proton-mail-export-to-gmail</description>
 	<url/>

--- a/modules/export-to-gmail/src/main/resources/application.yml
+++ b/modules/export-to-gmail/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
     application:
         name: proton-mail-export-to-gmail
     datasource:
-        url: jdbc:h2:file:${pmetg.database.file-path};AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+        url: jdbc:h2:file:${pmetg.database.file-path};AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1
         driver-class-name: org.h2.Driver
         username: sa
         password: ""


### PR DESCRIPTION
## Summary
- remove the unsupported DB_CLOSE_ON_EXIT flag from the dev H2 datasource URL so the embedded database can start
- bump the module version to 0.0.15-SNAPSHOT

## Testing
- mvn clean package

------
https://chatgpt.com/codex/tasks/task_e_68e3640cb34c832b88071d2774e23be2