### PR TITLE
Refactor Gmail header flow

### DIFF
--- a/modules/export-to-gmail/pom.xml
+++ b/modules/export-to-gmail/pom.xml
@@ -10,7 +10,7 @@
         </parent>
 	<groupId>com.github.sigmalko.pmetg</groupId>
 	        <artifactId>proton-mail-export-to-gmail</artifactId>
-    <version>0.0.20-SNAPSHOT</version>
+    <version>0.0.21-SNAPSHOT</version>
 	<name>proton-mail-export-to-gmail</name>
 	<description>proton-mail-export-to-gmail</description>
 	<url/>

--- a/modules/export-to-gmail/src/main/java/com/github/sigmalko/pmetg/gmail/GmailEmailHeaderMapper.java
+++ b/modules/export-to-gmail/src/main/java/com/github/sigmalko/pmetg/gmail/GmailEmailHeaderMapper.java
@@ -1,0 +1,69 @@
+package com.github.sigmalko.pmetg.gmail;
+
+import jakarta.mail.Address;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j(topic = "GmailEmailHeaderMapper")
+@Component
+public class GmailEmailHeaderMapper {
+
+        public void map(Message message, Consumer<? super EmailHeader> consumer) {
+                map(message).ifPresent(consumer);
+        }
+
+        public Optional<EmailHeader> map(Message message) {
+                final int messageNumber = message.getMessageNumber();
+
+                try {
+                        return Optional.of(new EmailHeader(
+                                        messageNumber,
+                                        firstHeaderValue(message, "Message-ID"),
+                                        resolveSentAt(message),
+                                        formatAddresses(message.getFrom())));
+                } catch (MessagingException exception) {
+                        log.warn("Failed to extract headers for message {}.", messageNumber, exception);
+                        return Optional.empty();
+                }
+        }
+
+        private Instant resolveSentAt(Message message) throws MessagingException {
+                return message.getSentDate() != null ? message.getSentDate().toInstant() : null;
+        }
+
+        private String firstHeaderValue(Message message, String headerName) throws MessagingException {
+                final var headerValues = message.getHeader(headerName);
+                if (headerValues == null || headerValues.length == 0) {
+                        return null;
+                }
+
+                return headerValues[0];
+        }
+
+        private String formatAddresses(Address[] addresses) {
+                if (addresses == null || addresses.length == 0) {
+                        return "";
+                }
+
+                return Arrays.stream(addresses)
+                                .map(this::formatAddress)
+                                .filter(address -> !address.isEmpty())
+                                .collect(Collectors.joining(", "));
+        }
+
+        private String formatAddress(Address address) {
+                return switch (address) {
+                case InternetAddress internetAddress -> internetAddress.toUnicodeString();
+                case null -> "";
+                default -> address.toString();
+                };
+        }
+}

--- a/modules/export-to-gmail/src/main/java/com/github/sigmalko/pmetg/gmail/GmailHeaderSynchronizer.java
+++ b/modules/export-to-gmail/src/main/java/com/github/sigmalko/pmetg/gmail/GmailHeaderSynchronizer.java
@@ -1,0 +1,76 @@
+package com.github.sigmalko.pmetg.gmail;
+
+import com.github.sigmalko.pmetg.migrations.MigrationEntity;
+import com.github.sigmalko.pmetg.migrations.MigrationService;
+import com.github.sigmalko.pmetg.migrations.MigrationService.MigrationFlag;
+import com.github.sigmalko.pmetg.problems.ProblemService;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Slf4j(topic = "GmailHeaderSynchronizer")
+@Component
+@RequiredArgsConstructor
+public class GmailHeaderSynchronizer {
+
+        private final MigrationService migrationService;
+        private final ProblemService problemService;
+
+        public void synchronize(List<EmailHeader> headers) {
+                headers.forEach(this::synchronizeHeader);
+        }
+
+        private void synchronizeHeader(EmailHeader header) {
+                final OffsetDateTime messageDate = header.sentAt() != null
+                                ? OffsetDateTime.ofInstant(header.sentAt(), ZoneOffset.UTC)
+                                : null;
+
+                try {
+                        if (!StringUtils.hasText(header.messageId())) {
+                                log.debug(
+                                                "Skipping Gmail message {} because it does not contain Message-ID header.",
+                                                header.messageNumber());
+                                problemService.logRemoteProblem(
+                                                messageDate,
+                                                header.from(),
+                                                "Missing Message-ID header for Gmail message number "
+                                                                + header.messageNumber());
+                                return;
+                        }
+
+                        final var existing = migrationService.findByMessageId(header.messageId());
+                        if (existing.isPresent()) {
+                                markMessageAsExisting(existing.get());
+                        } else {
+                                migrationService.createGmailMigration(header.messageId(), messageDate);
+                        }
+                } catch (Exception exception) {
+                        if (!StringUtils.hasText(header.messageId())) {
+                                log.warn(
+                                                "Failed to log missing Message-ID problem for Gmail message {}.",
+                                                header.messageNumber(),
+                                                exception);
+                                return;
+                        }
+
+                        log.warn(
+                                        "Failed to persist Gmail message {} (messageId={}).",
+                                        header.messageNumber(),
+                                        header.messageId(),
+                                        exception);
+                }
+        }
+
+        private void markMessageAsExisting(MigrationEntity entity) {
+                if (entity.isMessageAlreadyExists()) {
+                        return;
+                }
+
+                migrationService.updateFlagByMessageId(
+                                entity.getMessageId(), MigrationFlag.MESSAGE_ALREADY_EXISTS, true);
+        }
+}

--- a/modules/export-to-gmail/src/test/java/com/github/sigmalko/pmetg/gmail/GmailEmailHeaderMapperTest.java
+++ b/modules/export-to-gmail/src/test/java/com/github/sigmalko/pmetg/gmail/GmailEmailHeaderMapperTest.java
@@ -1,0 +1,96 @@
+package com.github.sigmalko.pmetg.gmail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.mail.Address;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class GmailEmailHeaderMapperTest {
+
+        private final GmailEmailHeaderMapper mapper = new GmailEmailHeaderMapper();
+
+        @Test
+        void mapReturnsEmailHeaderWhenMessageReadable() throws Exception {
+                final Message message = mock(Message.class);
+                final Instant sentAt = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+
+                when(message.getMessageNumber()).thenReturn(42);
+                when(message.getHeader("Message-ID")).thenReturn(new String[] {"<id-42>"});
+                when(message.getSentDate()).thenReturn(Date.from(sentAt));
+                when(message.getFrom()).thenReturn(new Address[] {new InternetAddress("John Doe <john@example.com>")});
+
+                final Optional<EmailHeader> result = mapper.map(message);
+
+                assertThat(result).isPresent();
+                assertThat(result.get())
+                                .extracting(EmailHeader::messageNumber, EmailHeader::messageId, EmailHeader::sentAt, EmailHeader::from)
+                                .containsExactly(42, "<id-42>", sentAt, "John Doe <john@example.com>");
+        }
+
+        @Test
+        void mapFormatsNonInternetAddressesUsingToString() throws Exception {
+                final Message message = mock(Message.class);
+                final Address customAddress = new CustomAddress("custom-address");
+                when(message.getMessageNumber()).thenReturn(100);
+                when(message.getHeader("Message-ID")).thenReturn(new String[] {"<id-100>"});
+                when(message.getSentDate()).thenReturn(null);
+                when(message.getFrom()).thenReturn(new Address[] {customAddress, null});
+
+                final Optional<EmailHeader> result = mapper.map(message);
+
+                assertThat(result).isPresent();
+                assertThat(result.get().from()).isEqualTo("custom-address");
+        }
+
+        @Test
+        void mapReturnsEmptyWhenMessagingExceptionThrown() throws Exception {
+                final Message message = mock(Message.class);
+
+                when(message.getMessageNumber()).thenReturn(7);
+                when(message.getHeader("Message-ID")).thenThrow(new MessagingException("boom"));
+
+                assertThat(mapper.map(message)).isEmpty();
+        }
+        private static final class CustomAddress extends Address {
+                private final String value;
+
+                private CustomAddress(String value) {
+                        this.value = value;
+                }
+
+                @Override
+                public String getType() {
+                        return "custom";
+                }
+
+                @Override
+                public String toString() {
+                        return value;
+                }
+
+                @Override
+                public boolean equals(Object obj) {
+                        if (this == obj) {
+                                return true;
+                        }
+                        if (!(obj instanceof CustomAddress other)) {
+                                return false;
+                        }
+                        return value.equals(other.value);
+                }
+
+                @Override
+                public int hashCode() {
+                        return value.hashCode();
+                }
+        }
+}

--- a/modules/export-to-gmail/src/test/java/com/github/sigmalko/pmetg/gmail/GmailHeaderSynchronizerTest.java
+++ b/modules/export-to-gmail/src/test/java/com/github/sigmalko/pmetg/gmail/GmailHeaderSynchronizerTest.java
@@ -1,0 +1,107 @@
+package com.github.sigmalko.pmetg.gmail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.github.sigmalko.pmetg.migrations.MigrationEntity;
+import com.github.sigmalko.pmetg.migrations.MigrationService;
+import com.github.sigmalko.pmetg.migrations.MigrationService.MigrationFlag;
+import com.github.sigmalko.pmetg.problems.ProblemService;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class GmailHeaderSynchronizerTest {
+
+        private MigrationService migrationService;
+        private ProblemService problemService;
+        private GmailHeaderSynchronizer synchronizer;
+
+        @BeforeEach
+        void setUp() {
+                migrationService = mock(MigrationService.class);
+                problemService = mock(ProblemService.class);
+                synchronizer = new GmailHeaderSynchronizer(migrationService, problemService);
+        }
+
+        @Test
+        void synchronizeLogsProblemWhenMessageIdMissing() {
+                final Instant sentAt = Instant.parse("2024-01-01T10:15:30Z");
+                final EmailHeader header = new EmailHeader(1, " ", sentAt, "Alice <alice@example.com>");
+                final var expectedDiagnostics = "Missing Message-ID header for Gmail message number " + header.messageNumber();
+
+                synchronizer.synchronize(List.of(header));
+
+                final ArgumentCaptor<OffsetDateTime> dateCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
+                verify(problemService).logRemoteProblem(
+                                dateCaptor.capture(),
+                                eq(header.from()),
+                                eq(expectedDiagnostics));
+                verifyOffsetDate(dateCaptor.getValue(), sentAt);
+                verifyNoMoreInteractions(migrationService);
+        }
+
+        @Test
+        void synchronizeCreatesMigrationWhenNotExisting() {
+                final Instant sentAt = Instant.parse("2024-02-02T02:02:02Z");
+                final EmailHeader header = new EmailHeader(2, "<id-2>", sentAt, "Bob <bob@example.com>");
+
+                when(migrationService.findByMessageId("<id-2>")).thenReturn(Optional.empty());
+
+                synchronizer.synchronize(List.of(header));
+
+                verify(migrationService).findByMessageId("<id-2>");
+                verify(migrationService).createGmailMigration("<id-2>", OffsetDateTime.ofInstant(sentAt, ZoneOffset.UTC));
+                verifyNoMoreInteractions(problemService);
+        }
+
+        @Test
+        void synchronizeUpdatesExistingFlagWhenNeeded() {
+                final EmailHeader header = new EmailHeader(3, "<id-3>", null, "Carol");
+                final MigrationEntity entity = MigrationEntity.builder()
+                                .messageId("<id-3>")
+                                .messageAlreadyExists(false)
+                                .build();
+
+                when(migrationService.findByMessageId("<id-3>")).thenReturn(Optional.of(entity));
+
+                synchronizer.synchronize(List.of(header));
+
+                verify(migrationService).findByMessageId("<id-3>");
+                verify(migrationService).updateFlagByMessageId("<id-3>", MigrationFlag.MESSAGE_ALREADY_EXISTS, true);
+                verifyNoMoreInteractions(problemService);
+        }
+
+        @Test
+        void synchronizeSkipsUpdatingFlagWhenAlreadySet() {
+                final EmailHeader header = new EmailHeader(4, "<id-4>", null, "Dana");
+                final MigrationEntity entity = MigrationEntity.builder()
+                                .messageId("<id-4>")
+                                .messageAlreadyExists(true)
+                                .build();
+
+                when(migrationService.findByMessageId("<id-4>")).thenReturn(Optional.of(entity));
+
+                synchronizer.synchronize(List.of(header));
+
+                verify(migrationService).findByMessageId("<id-4>");
+                verify(migrationService, never())
+                                .updateFlagByMessageId("<id-4>", MigrationFlag.MESSAGE_ALREADY_EXISTS, true);
+                verifyNoMoreInteractions(problemService);
+        }
+
+        private void verifyOffsetDate(OffsetDateTime value, Instant expected) {
+                assertThat(value).isEqualTo(OffsetDateTime.ofInstant(expected, ZoneOffset.UTC));
+        }
+
+}


### PR DESCRIPTION
## Summary
- add a GmailEmailHeaderMapper component that maps IMAP messages to EmailHeader instances while handling address formatting and logging failures
- introduce a GmailHeaderSynchronizer to encapsulate migration/problem side effects and update GmailImapFetcher to stream headers via mapMulti before logging
- cover the new mapper and synchronizer with unit tests and bump the module version

## Testing
- mvn clean package

------
https://chatgpt.com/codex/tasks/task_e_68e3822b783c832b967394e8663ce459