### PR TITLE
Refactor Gmail IMAP client resource management

### DIFF
--- a/modules/export-to-gmail/pom.xml
+++ b/modules/export-to-gmail/pom.xml
@@ -10,7 +10,7 @@
         </parent>
 	<groupId>com.github.sigmalko.pmetg</groupId>
 	        <artifactId>proton-mail-export-to-gmail</artifactId>
-    <version>0.0.21-SNAPSHOT</version>
+    <version>0.0.22-SNAPSHOT</version>
 	<name>proton-mail-export-to-gmail</name>
 	<description>proton-mail-export-to-gmail</description>
 	<url/>

--- a/modules/export-to-gmail/src/main/java/com/github/sigmalko/pmetg/gmail/GmailImapClientSupport.java
+++ b/modules/export-to-gmail/src/main/java/com/github/sigmalko/pmetg/gmail/GmailImapClientSupport.java
@@ -45,22 +45,58 @@ public class GmailImapClientSupport {
                 return properties.sslEnabled() ? "imaps" : "imap";
         }
 
-        public void closeFolder(Folder folder) {
-                if (folder != null && folder.isOpen()) {
-                        try {
-                                folder.close(false);
-                        } catch (MessagingException exception) {
-                                log.warn("Failed to close IMAP folder cleanly.", exception);
-                        }
-                }
+        public FolderSession openReadOnlyFolder(String folder) throws MessagingException {
+                return openFolder(folder, Folder.READ_ONLY);
         }
 
-        public void closeStore(Store store) {
-                if (store != null && store.isConnected()) {
-                        try {
-                                store.close();
-                        } catch (MessagingException exception) {
-                                log.warn("Failed to close IMAP store cleanly.", exception);
+        public FolderSession openFolder(String folderName, int mode) throws MessagingException {
+                final var session = createSession();
+                final var store = session.getStore(resolveProtocol());
+
+                log.info(
+                                "Connecting to Gmail IMAP server {}:{} using SSL: {}",
+                                properties.host(),
+                                properties.port(),
+                                properties.sslEnabled());
+                store.connect(properties.host(), properties.port(), properties.username(), properties.password());
+                log.info("store.isConnected(): {}", store.isConnected());
+
+                final var targetFolder = store.getFolder(folderName);
+                if (targetFolder == null) {
+                        throw new MessagingException("IMAP folder '%s' could not be resolved.".formatted(folderName));
+                }
+
+                if (!targetFolder.exists() && mode != Folder.READ_ONLY) {
+                        log.info("IMAP folder '{}' does not exist. Creating it now...", folderName);
+                        targetFolder.create(Folder.HOLDS_MESSAGES);
+                }
+
+                if (!targetFolder.exists()) {
+                        throw new MessagingException("IMAP folder '%s' does not exist.".formatted(folderName));
+                }
+
+                targetFolder.open(mode);
+                return new FolderSession(store, targetFolder);
+        }
+
+        public record FolderSession(Store store, Folder folder) implements AutoCloseable {
+
+                @Override
+                public void close() {
+                        if (folder != null && folder.isOpen()) {
+                                try {
+                                        folder.close(false);
+                                } catch (MessagingException exception) {
+                                        log.warn("Failed to close IMAP folder cleanly.", exception);
+                                }
+                        }
+
+                        if (store != null && store.isConnected()) {
+                                try {
+                                        store.close();
+                                } catch (MessagingException exception) {
+                                        log.warn("Failed to close IMAP store cleanly.", exception);
+                                }
                         }
                 }
         }

--- a/modules/export-to-gmail/src/main/java/com/github/sigmalko/pmetg/gmail/GmailImapProperties.java
+++ b/modules/export-to-gmail/src/main/java/com/github/sigmalko/pmetg/gmail/GmailImapProperties.java
@@ -8,6 +8,7 @@ public record GmailImapProperties(
         @DefaultValue("imap.gmail.com") String host,
         @DefaultValue("993") int port,
         @DefaultValue("true") boolean sslEnabled,
+        @DefaultValue("INBOX") String folder,
         String username,
         String password,
         @DefaultValue("50") int messageLimit

--- a/modules/export-to-gmail/src/main/resources/application.yml
+++ b/modules/export-to-gmail/src/main/resources/application.yml
@@ -37,6 +37,7 @@ gmail:
     host: ${GMAIL_IMAP_HOST:imap.gmail.com}
     port: ${GMAIL_IMAP_PORT:993}
     ssl-enabled: ${GMAIL_IMAP_SSL_ENABLED:true}
+    folder: ${GMAIL_IMAP_FOLDER:INBOX}
     username: ${GMAIL_IMAP_USERNAME:}
     password: ${GMAIL_IMAP_PASSWORD:}
     message-limit: ${GMAIL_IMAP_MESSAGE_LIMIT:50}


### PR DESCRIPTION
## Summary
- introduce an auto-closeable FolderSession in GmailImapClientSupport with helpers to open folders safely
- update the IMAP fetcher and fake message generator to rely on the new client API and the configurable folder name
- add an application property for the target folder (defaulting to INBOX), refresh tests, and bump the module version

## Testing
- mvn clean package

------
https://chatgpt.com/codex/tasks/task_e_68e38b0d636c832ba4cd28c120bef74f