### PR TITLE
Add Gmail readable folder discovery

### DIFF
--- a/modules/export-to-gmail/pom.xml
+++ b/modules/export-to-gmail/pom.xml
@@ -10,7 +10,7 @@
         </parent>
 	<groupId>com.github.sigmalko.pmetg</groupId>
 	        <artifactId>proton-mail-export-to-gmail</artifactId>
-    <version>0.0.21-SNAPSHOT</version>
+    <version>0.0.22-SNAPSHOT</version>
 	<name>proton-mail-export-to-gmail</name>
 	<description>proton-mail-export-to-gmail</description>
 	<url/>


### PR DESCRIPTION
## Summary
- add a GmailImapFetcher API that discovers all folders capable of holding messages and logs the results
- reuse the folder topology traversal to collect readable folder names while still logging the structure
- bump the module version to 0.0.22-SNAPSHOT

## Testing
- mvn clean package

------
https://chatgpt.com/codex/tasks/task_e_68e38ebbc004832baecd890bb3721860