### PR TITLE
Add readable Gmail folder discovery

### DIFF
--- a/modules/export-to-gmail/pom.xml
+++ b/modules/export-to-gmail/pom.xml
@@ -10,7 +10,7 @@
         </parent>
 	<groupId>com.github.sigmalko.pmetg</groupId>
 	        <artifactId>proton-mail-export-to-gmail</artifactId>
-    <version>0.0.22-SNAPSHOT</version>
+    <version>0.0.23-SNAPSHOT</version>
 	<name>proton-mail-export-to-gmail</name>
 	<description>proton-mail-export-to-gmail</description>
 	<url/>


### PR DESCRIPTION
## Summary
- add a Gmail IMAP fetcher method that discovers readable folders and logs them clearly
- refactor folder topology traversal to reuse a descriptor-based visitor and support folder collection
- bump the module version to 0.0.23-SNAPSHOT

## Testing
- mvn clean package

------
https://chatgpt.com/codex/tasks/task_e_68e393732e54832b81c67967122956e5