### PR TITLE
Add migration update queries and projections

### DIFF
--- a/modules/export-to-gmail/pom.xml
+++ b/modules/export-to-gmail/pom.xml
@@ -10,7 +10,7 @@
         </parent>
 	<groupId>com.github.sigmalko.pmetg</groupId>
 	        <artifactId>proton-mail-export-to-gmail</artifactId>
-    <version>0.0.23-SNAPSHOT</version>
+    <version>0.0.24-SNAPSHOT</version>
 	<name>proton-mail-export-to-gmail</name>
 	<description>proton-mail-export-to-gmail</description>
 	<url/>

--- a/modules/export-to-gmail/src/main/java/com/github/sigmalko/pmetg/eml/EmlEmailLoggingRunner.java
+++ b/modules/export-to-gmail/src/main/java/com/github/sigmalko/pmetg/eml/EmlEmailLoggingRunner.java
@@ -25,9 +25,9 @@ import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import com.github.sigmalko.pmetg.migrations.MigrationEntity;
 import com.github.sigmalko.pmetg.migrations.MigrationService;
 import com.github.sigmalko.pmetg.migrations.MigrationService.MigrationFlag;
+import com.github.sigmalko.pmetg.migrations.MigrationRepository.MigrationStatus;
 import com.github.sigmalko.pmetg.problems.ProblemService;
 
 @Slf4j(topic = "EmlEmailLoggingRunner")
@@ -172,12 +172,12 @@ public class EmlEmailLoggingRunner implements CommandLineRunner {
         }
     }
 
-    private void markMessageAsStoredInFile(MigrationEntity entity) {
-        if (entity.isMessageInFile()) {
+    private void markMessageAsStoredInFile(MigrationStatus status) {
+        if (status.messageInFile()) {
             return;
         }
 
         migrationService.updateFlagByMessageId(
-                entity.getMessageId(), MigrationFlag.MESSAGE_IN_FILE, true);
+                status.messageId(), MigrationFlag.MESSAGE_IN_FILE, true);
     }
 }

--- a/modules/export-to-gmail/src/main/java/com/github/sigmalko/pmetg/gmail/GmailHeaderSynchronizer.java
+++ b/modules/export-to-gmail/src/main/java/com/github/sigmalko/pmetg/gmail/GmailHeaderSynchronizer.java
@@ -1,8 +1,8 @@
 package com.github.sigmalko.pmetg.gmail;
 
-import com.github.sigmalko.pmetg.migrations.MigrationEntity;
 import com.github.sigmalko.pmetg.migrations.MigrationService;
 import com.github.sigmalko.pmetg.migrations.MigrationService.MigrationFlag;
+import com.github.sigmalko.pmetg.migrations.MigrationRepository.MigrationStatus;
 import com.github.sigmalko.pmetg.problems.ProblemService;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -65,12 +65,12 @@ public class GmailHeaderSynchronizer {
                 }
         }
 
-        private void markMessageAsExisting(MigrationEntity entity) {
-                if (entity.isMessageAlreadyExists()) {
+        private void markMessageAsExisting(MigrationStatus status) {
+                if (status.messageAlreadyExists()) {
                         return;
                 }
 
                 migrationService.updateFlagByMessageId(
-                                entity.getMessageId(), MigrationFlag.MESSAGE_ALREADY_EXISTS, true);
+                                status.messageId(), MigrationFlag.MESSAGE_ALREADY_EXISTS, true);
         }
 }

--- a/modules/export-to-gmail/src/main/java/com/github/sigmalko/pmetg/migrations/MigrationRepository.java
+++ b/modules/export-to-gmail/src/main/java/com/github/sigmalko/pmetg/migrations/MigrationRepository.java
@@ -1,16 +1,43 @@
 package com.github.sigmalko.pmetg.migrations;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MigrationRepository extends JpaRepository<MigrationEntity, Long> {
 
-    Optional<MigrationEntity> findByMessageId(String messageId);
+    Optional<MigrationStatus> findByMessageId(String messageId);
 
-    List<MigrationEntity> findAllByMessageAlreadyExistsFalse();
+    List<MigrationStatus> findAllByMessageAlreadyExistsFalse();
 
-    List<MigrationEntity> findAllByMessageExportedFalse();
+    List<MigrationStatus> findAllByMessageExportedFalse();
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update MigrationEntity m set m.messageInFile = :value where m.messageId = :messageId")
+    int updateMessageInFileByMessageId(
+            @Param("messageId") String messageId, @Param("value") boolean value);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+            "update MigrationEntity m set m.messageAlreadyExists = :value where m.messageId = :messageId")
+    int updateMessageAlreadyExistsByMessageId(
+            @Param("messageId") String messageId, @Param("value") boolean value);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update MigrationEntity m set m.messageExported = :value where m.messageId = :messageId")
+    int updateMessageExportedByMessageId(
+            @Param("messageId") String messageId, @Param("value") boolean value);
+
+    record MigrationStatus(
+            String messageId,
+            OffsetDateTime messageDate,
+            boolean messageInFile,
+            boolean messageAlreadyExists,
+            boolean messageExported) {}
 }

--- a/modules/export-to-gmail/src/test/java/com/github/sigmalko/pmetg/gmail/GmailHeaderSynchronizerTest.java
+++ b/modules/export-to-gmail/src/test/java/com/github/sigmalko/pmetg/gmail/GmailHeaderSynchronizerTest.java
@@ -8,9 +8,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import com.github.sigmalko.pmetg.migrations.MigrationEntity;
 import com.github.sigmalko.pmetg.migrations.MigrationService;
 import com.github.sigmalko.pmetg.migrations.MigrationService.MigrationFlag;
+import com.github.sigmalko.pmetg.migrations.MigrationRepository.MigrationStatus;
 import com.github.sigmalko.pmetg.problems.ProblemService;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -68,12 +68,9 @@ class GmailHeaderSynchronizerTest {
         @Test
         void synchronizeUpdatesExistingFlagWhenNeeded() {
                 final EmailHeader header = new EmailHeader(3, "<id-3>", null, "Carol");
-                final MigrationEntity entity = MigrationEntity.builder()
-                                .messageId("<id-3>")
-                                .messageAlreadyExists(false)
-                                .build();
+                final MigrationStatus status = new MigrationStatus("<id-3>", null, false, false, false);
 
-                when(migrationService.findByMessageId("<id-3>")).thenReturn(Optional.of(entity));
+                when(migrationService.findByMessageId("<id-3>")).thenReturn(Optional.of(status));
 
                 synchronizer.synchronize(List.of(header));
 
@@ -85,12 +82,9 @@ class GmailHeaderSynchronizerTest {
         @Test
         void synchronizeSkipsUpdatingFlagWhenAlreadySet() {
                 final EmailHeader header = new EmailHeader(4, "<id-4>", null, "Dana");
-                final MigrationEntity entity = MigrationEntity.builder()
-                                .messageId("<id-4>")
-                                .messageAlreadyExists(true)
-                                .build();
+                final MigrationStatus status = new MigrationStatus("<id-4>", null, false, true, false);
 
-                when(migrationService.findByMessageId("<id-4>")).thenReturn(Optional.of(entity));
+                when(migrationService.findByMessageId("<id-4>")).thenReturn(Optional.of(status));
 
                 synchronizer.synchronize(List.of(header));
 


### PR DESCRIPTION
## Summary
- add dedicated update queries for migration flags and expose a MigrationStatus record projection
- refactor MigrationService and callers to use the projection-based dispatcher and simplified flag updates
- bump the module version and align tests with the new projection-based API

## Testing
- mvn clean package

------
https://chatgpt.com/codex/tasks/task_e_68e39941595c832bbd41a97021b1fb8a