### PR TITLE
Refine client IP lookup and header matching

### DIFF
--- a/modules/export-to-gmail/pom.xml
+++ b/modules/export-to-gmail/pom.xml
@@ -10,7 +10,7 @@
         </parent>
         <groupId>com.github.sigmalko.protonmail.export</groupId>
                 <artifactId>proton-mail-export-to-gmail</artifactId>
-    <version>0.0.26-SNAPSHOT</version>
+    <version>0.0.27-SNAPSHOT</version>
 	<name>proton-mail-export-to-gmail</name>
 	<description>proton-mail-export-to-gmail</description>
 	<url/>


### PR DESCRIPTION
## Summary
- derive the client IP from a prioritized header list using stream-based filtering
- modernize headerContainsIgnoreCase with a switch expression and streamlined fragment checks
- bump the module version to 0.0.27-SNAPSHOT

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3bb23aa70832b891ae2ba7002b71a