### PR TITLE
Resolve RequestUtils header switch compilation error

### DIFF
--- a/modules/export-to-gmail/src/main/java/com/github/sigmalko/protonmail/export/web/support/RequestUtils.java
+++ b/modules/export-to-gmail/src/main/java/com/github/sigmalko/protonmail/export/web/support/RequestUtils.java
@@ -80,15 +80,15 @@ public final class RequestUtils {
             return false;
         }
 
-        return switch (request.getHeader(header)) {
-            case null, String s when s.isBlank() -> false;
-            case String headerValue -> {
-                final String normalizedHeader = headerValue.toLowerCase(Locale.ROOT);
-                yield Arrays.stream(fragments)
-                        .filter(Objects::nonNull)
-                        .map(fragment -> fragment.toLowerCase(Locale.ROOT))
-                        .anyMatch(normalizedHeader::contains);
-            }
-        };
+        final String headerValue = request.getHeader(header);
+        if (headerValue == null || headerValue.isBlank()) {
+            return false;
+        }
+
+        final String normalizedHeader = headerValue.toLowerCase(Locale.ROOT);
+        return Arrays.stream(fragments)
+                .filter(Objects::nonNull)
+                .map(fragment -> fragment.toLowerCase(Locale.ROOT))
+                .anyMatch(normalizedHeader::contains);
     }
 }


### PR DESCRIPTION
## Summary
- guard against null or blank header values in RequestUtils without relying on pattern switches that fail compilation

## Testing
- `mvn -DskipTests package`


------
https://chatgpt.com/codex/tasks/task_e_68e3be8a3710832b9db37bf96f45ccdc