### PR TITLE
Configure UTF-8 encoding via Spring properties

### DIFF
--- a/modules/export-to-gmail/pom.xml
+++ b/modules/export-to-gmail/pom.xml
@@ -10,7 +10,7 @@
         </parent>
         <groupId>com.github.sigmalko.protonmail.export</groupId>
                 <artifactId>proton-mail-export-to-gmail</artifactId>
-    <version>0.0.27-SNAPSHOT</version>
+    <version>0.0.28-SNAPSHOT</version>
 	<name>proton-mail-export-to-gmail</name>
 	<description>proton-mail-export-to-gmail</description>
 	<url/>

--- a/modules/export-to-gmail/src/main/java/com/github/sigmalko/protonmail/export/config/web/WebInfrastructureConfig.java
+++ b/modules/export-to-gmail/src/main/java/com/github/sigmalko/protonmail/export/config/web/WebInfrastructureConfig.java
@@ -6,25 +6,11 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
-import org.springframework.web.filter.CharacterEncodingFilter;
 
 import com.github.sigmalko.protonmail.export.web.filter.CORSFilter;
 
 @Configuration
 public class WebInfrastructureConfig {
-
-    @Bean
-    FilterRegistrationBean<CharacterEncodingFilter> characterEncodingFilterRegistration() {
-        final var filter = new CharacterEncodingFilter();
-        filter.setEncoding("UTF-8");
-        filter.setForceEncoding(true);
-        filter.setForceRequestEncoding(true);
-        filter.setForceResponseEncoding(false);
-
-        final var registrationBean = new FilterRegistrationBean<>(filter);
-        registrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE + 1);
-        return registrationBean;
-    }
 
     @Bean
     FilterRegistrationBean<CORSFilter> corsFilterRegistration(CORSFilter corsFilter) {

--- a/modules/export-to-gmail/src/main/resources/application.yml
+++ b/modules/export-to-gmail/src/main/resources/application.yml
@@ -1,6 +1,12 @@
 spring:
     application:
         name: proton-mail-export-to-gmail
+    servlet:
+        encoding:
+            charset: UTF-8
+            force-request: true
+            force-response: true
+            enabled: true
     datasource:
         url: jdbc:h2:file:${protonmail-export.database.file-path};AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1
         driver-class-name: org.h2.Driver


### PR DESCRIPTION
## Summary
- remove the custom `CharacterEncodingFilter` registration in `WebInfrastructureConfig`
- configure UTF-8 request/response handling through `spring.servlet.encoding` properties in `application.yml`
- bump the module version to 0.0.28-SNAPSHOT

## Testing
- mvn clean package

------
https://chatgpt.com/codex/tasks/task_e_68e3cfcd554c832bbc371b8b04a4a50e