### PR TITLE
Add feature flags for optional command-line runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,25 @@ You need a Gmail account (`gmail.com`) to which the `proton-mail-export-to-gmail
 - Spring-Boot Mail
 - DevContainer & Visual Studio Code
 
+## Optional command-line runners
+
+The application contains optional `CommandLineRunner` components that are disabled by default. Enable them explicitly when you 
+need to work with local EML files or fetch message headers from Gmail:
+
+| Runner | Property | Environment variable | Description |
+| --- | --- | --- | --- |
+| `EmlEmailLoggingRunner` | `eml.reader.enabled` | `EML_READER_ENABLED` | Scans a local directory of exported EML files and logs their headers. Requires `eml.reader.directory`/`EML_READER_DIRECTORY` to point to a readable folder. |
+| `GmailImapFetchRunner` | `gmail.imap.fetch-enabled` | `GMAIL_IMAP_FETCH_ENABLED` | Downloads the latest Gmail message headers over IMAP using the configured credentials. |
+
+To run a runner locally, pass the relevant flag when starting Spring Boot. For example:
+
+```bash
+mvn -pl modules/export-to-gmail spring-boot:run \
+  -Dspring-boot.run.arguments="--eml.reader.enabled=true --eml.reader.directory=/path/to/eml"
+```
+
+Omit the flags (or set them to `false`) to skip running the associated tasks.
+
 # Required Resources
 
 - Create an account on **gmail.com**  

--- a/modules/export-to-gmail/pom.xml
+++ b/modules/export-to-gmail/pom.xml
@@ -10,7 +10,7 @@
         </parent>
         <groupId>com.github.sigmalko.protonmail.export</groupId>
                 <artifactId>proton-mail-export-to-gmail</artifactId>
-    <version>0.0.27-SNAPSHOT</version>
+    <version>0.0.28-SNAPSHOT</version>
 	<name>proton-mail-export-to-gmail</name>
 	<description>proton-mail-export-to-gmail</description>
 	<url/>

--- a/modules/export-to-gmail/src/main/java/com/github/sigmalko/protonmail/export/integration/eml/EmlEmailLoggingRunner.java
+++ b/modules/export-to-gmail/src/main/java/com/github/sigmalko/protonmail/export/integration/eml/EmlEmailLoggingRunner.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import java.util.Properties;
 
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -34,6 +35,7 @@ import com.github.sigmalko.protonmail.export.domain.problem.ProblemService;
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
 @RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "eml.reader", name = "enabled", havingValue = "true")
 public class EmlEmailLoggingRunner implements CommandLineRunner {
 
     private static final Session MAIL_SESSION = Session.getInstance(new Properties());

--- a/modules/export-to-gmail/src/main/java/com/github/sigmalko/protonmail/export/integration/eml/EmlReaderProperties.java
+++ b/modules/export-to-gmail/src/main/java/com/github/sigmalko/protonmail/export/integration/eml/EmlReaderProperties.java
@@ -1,7 +1,10 @@
 package com.github.sigmalko.protonmail.export.integration.eml;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
 
 @ConfigurationProperties(prefix = "eml.reader")
-public record EmlReaderProperties(String directory) {
+public record EmlReaderProperties(
+        @DefaultValue("false") boolean enabled,
+        String directory) {
 }

--- a/modules/export-to-gmail/src/main/java/com/github/sigmalko/protonmail/export/integration/gmail/GmailImapFetchRunner.java
+++ b/modules/export-to-gmail/src/main/java/com/github/sigmalko/protonmail/export/integration/gmail/GmailImapFetchRunner.java
@@ -4,27 +4,28 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.boot.CommandLineRunner;
-import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
 @Slf4j(topic = "GmailImapFetchRunner")
 @Component
 @RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "gmail.imap", name = "fetch-enabled", havingValue = "true")
 public class GmailImapFetchRunner implements CommandLineRunner {
 
-        private final GmailImapFetcher gmailImapFetcher;
-        private final ApplicationContext applicationContext;
+    private final GmailImapFetcher gmailImapFetcher;
+    private final ApplicationContext applicationContext;
 
-        @Override
-        public void run(String... args) {
-                log.info("##################################################");
-                log.info("Fetching latest email headers from Gmail via IMAP...");
-                log.info("##################################################");
+    @Override
+    public void run(String... args) {
+        log.info("##################################################");
+        log.info("Fetching latest email headers from Gmail via IMAP...");
+        log.info("##################################################");
 
-                gmailImapFetcher.fetchLatestHeaders();
-                log.info("IMAP header fetch complete. Shutting down the application.");
-                // final int exitCode = SpringApplication.exit(applicationContext, () -> 0);
-                // System.exit(exitCode);
-        }
+        gmailImapFetcher.fetchLatestHeaders();
+        log.info("IMAP header fetch complete. Shutting down the application.");
+        // final int exitCode = SpringApplication.exit(applicationContext, () -> 0);
+        // System.exit(exitCode);
+    }
 }

--- a/modules/export-to-gmail/src/main/java/com/github/sigmalko/protonmail/export/integration/gmail/GmailImapProperties.java
+++ b/modules/export-to-gmail/src/main/java/com/github/sigmalko/protonmail/export/integration/gmail/GmailImapProperties.java
@@ -5,6 +5,7 @@ import org.springframework.boot.context.properties.bind.DefaultValue;
 
 @ConfigurationProperties(prefix = "gmail.imap")
 public record GmailImapProperties(
+        @DefaultValue("false") boolean fetchEnabled,
         @DefaultValue("imap.gmail.com") String host,
         @DefaultValue("993") int port,
         @DefaultValue("true") boolean sslEnabled,

--- a/modules/export-to-gmail/src/main/resources/application.yml
+++ b/modules/export-to-gmail/src/main/resources/application.yml
@@ -30,10 +30,12 @@ protonmail-export:
 
 eml:
   reader:
+    enabled: ${EML_READER_ENABLED:false}
     directory: ${EML_READER_DIRECTORY:}
 
 gmail:
   imap:
+    fetch-enabled: ${GMAIL_IMAP_FETCH_ENABLED:false}
     host: ${GMAIL_IMAP_HOST:imap.gmail.com}
     port: ${GMAIL_IMAP_PORT:993}
     ssl-enabled: ${GMAIL_IMAP_SSL_ENABLED:true}


### PR DESCRIPTION
## Summary
- add configuration flags for the EML logging and Gmail IMAP fetch runners with production-safe defaults
- guard the command line runners with ConditionalOnProperty annotations and extend related configuration properties
- document how to enable the runners during local executions

## Testing
- mvn clean package
- mvn spring-boot:run -Dspring-boot.run.arguments="--spring.main.web-application-type=none"
- mvn spring-boot:run -Dspring-boot.run.arguments="--spring.main.web-application-type=none --eml.reader.enabled=true --eml.reader.directory=/tmp/emls"
- mvn spring-boot:run -Dspring-boot.run.arguments="--spring.main.web-application-type=none --gmail.imap.fetch-enabled=true"

------
https://chatgpt.com/codex/tasks/task_e_68e3cfea4710832b9832526a1f4d9a73