### PR TITLE
feat: fetch Gmail headers from all folders

### DIFF
--- a/modules/export-to-gmail/pom.xml
+++ b/modules/export-to-gmail/pom.xml
@@ -10,7 +10,7 @@
         </parent>
         <groupId>com.github.sigmalko.protonmail.export</groupId>
                 <artifactId>proton-mail-export-to-gmail</artifactId>
-    <version>0.0.31-SNAPSHOT</version>
+    <version>0.0.33-SNAPSHOT</version>
 	<name>proton-mail-export-to-gmail</name>
 	<description>proton-mail-export-to-gmail</description>
 	<url/>

--- a/modules/export-to-gmail/src/main/java/com/github/sigmalko/protonmail/export/integration/gmail/GmailImapProperties.java
+++ b/modules/export-to-gmail/src/main/java/com/github/sigmalko/protonmail/export/integration/gmail/GmailImapProperties.java
@@ -9,7 +9,6 @@ public record GmailImapProperties(
         @DefaultValue("imap.gmail.com") String host,
         @DefaultValue("993") int port,
         @DefaultValue("true") boolean sslEnabled,
-        @DefaultValue("INBOX") String folder,
         String username,
         String password,
         @DefaultValue("50") int messageLimit

--- a/modules/export-to-gmail/src/main/resources/application.yml
+++ b/modules/export-to-gmail/src/main/resources/application.yml
@@ -45,7 +45,6 @@ gmail:
     host: ${GMAIL_IMAP_HOST:imap.gmail.com}
     port: ${GMAIL_IMAP_PORT:993}
     ssl-enabled: ${GMAIL_IMAP_SSL_ENABLED:true}
-    folder: ${GMAIL_IMAP_FOLDER:INBOX}
     username: ${GMAIL_IMAP_USERNAME:}
     password: ${GMAIL_IMAP_PASSWORD:}
     message-limit: ${GMAIL_IMAP_MESSAGE_LIMIT:50}


### PR DESCRIPTION
## Summary
- discover Gmail folder topology through a shared store session and log the available folder names
- fetch headers from each readable folder using the configured message limit and close folders safely
- add reusable store connection support and bump the module version
- remove the now-unnecessary Gmail folder configuration property from the application settings

## Testing
- mvn clean package

------
https://chatgpt.com/codex/tasks/task_e_68e55940d0e8832b976c41e00a840115